### PR TITLE
Add functionality to get PointerShape

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+This fork adds basic cursor support (GetFramePointerShape) via grab_cursor function
+Its used for https://github.com/scamiv/ActiveClone
+
 # **DXcam**
 > ***Fastest Python Screenshot for Windows***
 ```python

--- a/dxcam/__init__.py
+++ b/dxcam/__init__.py
@@ -89,7 +89,9 @@ class DXFactory(metaclass=Singleton):
         ret = ""
         for didx, outputs in enumerate(self.outputs):
             for idx, output in enumerate(outputs):
+                #print(output)
                 ret += f"Device[{didx}] Output[{idx}]: "
+                ret += f"szDevice[{output.devicename}]: "
                 ret += f"Res:{output.resolution} Rot:{output.rotation_angle}"
                 ret += f" Primary:{self.output_metadata.get(output.devicename)[1]}\n"
         return ret

--- a/dxcam/__init__.py
+++ b/dxcam/__init__.py
@@ -85,11 +85,10 @@ class DXFactory(metaclass=Singleton):
             ret += f"Device[{idx}]:{device}\n"
         return ret
 
-    def output_info(self) -> str:
+    def output_info(self) -> str: 
         ret = ""
         for didx, outputs in enumerate(self.outputs):
             for idx, output in enumerate(outputs):
-                #print(output)
                 ret += f"Device[{didx}] Output[{idx}]: "
                 ret += f"szDevice[{output.devicename}]: "
                 ret += f"Res:{output.resolution} Rot:{output.rotation_angle}"

--- a/dxcam/_libs/dxgi.py
+++ b/dxcam/_libs/dxgi.py
@@ -42,6 +42,20 @@ class DXGI_OUTPUT_DESC(ctypes.Structure):
 class DXGI_OUTDUPL_POINTER_POSITION(ctypes.Structure):
     _fields_ = [("Position", wintypes.POINT), ("Visible", wintypes.BOOL)]
 
+class DXGI_OUTDUPL_POINTER_SHAPE_INFO(ctypes.Structure):
+    _fields_ = [('Type',    wintypes.UINT),
+                ('Width',   wintypes.UINT),
+                ('Height',  wintypes.UINT),
+                ('Pitch',   wintypes.UINT),
+                ('HotSpot', wintypes.POINT),
+    ]
+
+class ac_Cursor():
+    def __init__(self):
+        self.PointerPositionInfo: DXGI_OUTDUPL_POINTER_POSITION = DXGI_OUTDUPL_POINTER_POSITION()
+        self.PointerShapeInfo: DXGI_OUTDUPL_POINTER_SHAPE_INFO = DXGI_OUTDUPL_POINTER_SHAPE_INFO()
+        self.Shape: bytes = None
+
 
 class DXGI_OUTDUPL_FRAME_INFO(ctypes.Structure):
     _fields_ = [
@@ -113,7 +127,12 @@ class IDXGIOutputDuplication(IDXGIObject):
         ),
         comtypes.STDMETHOD(comtypes.HRESULT, "GetFrameDirtyRects"),
         comtypes.STDMETHOD(comtypes.HRESULT, "GetFrameMoveRects"),
-        comtypes.STDMETHOD(comtypes.HRESULT, "GetFramePointerShape"),
+        comtypes.STDMETHOD(comtypes.HRESULT, "GetFramePointerShape", [
+            wintypes.UINT,
+            ctypes.c_void_p,
+            ctypes.POINTER(wintypes.UINT),
+            ctypes.POINTER(DXGI_OUTDUPL_POINTER_SHAPE_INFO),
+            ]),
         comtypes.STDMETHOD(comtypes.HRESULT, "MapDesktopSurface"),
         comtypes.STDMETHOD(comtypes.HRESULT, "UnMapDesktopSurface"),
         comtypes.STDMETHOD(comtypes.HRESULT, "ReleaseFrame"),

--- a/dxcam/core/duplicator.py
+++ b/dxcam/core/duplicator.py
@@ -46,6 +46,12 @@ class Duplicator:
                 return True
             else:
                 raise ce
+
+        if info.LastPresentTime == 0: 
+            self.duplicator.ReleaseFrame()
+            self.updated = False
+            return True
+   
         try:
             self.texture = res.QueryInterface(ID3D11Texture2D)
         except comtypes.COMError as ce:

--- a/dxcam/core/duplicator.py
+++ b/dxcam/core/duplicator.py
@@ -14,9 +14,7 @@ class Duplicator:
     updated: bool = False
     output: InitVar[Output] = None
     device: InitVar[Device] = None
-    cursor = ac_Cursor()
-    cursor.shape: bytes = None
-    cursor.PointerShapeInfo: DXGI_OUTDUPL_POINTER_SHAPE_INFO = DXGI_OUTDUPL_POINTER_SHAPE_INFO()  
+    cursor: ac_Cursor = ac_Cursor()
 
     def __post_init__(self, output: Output, device: Device) -> None:
         self.duplicator = ctypes.POINTER(IDXGIOutputDuplication)()
@@ -47,10 +45,11 @@ class Duplicator:
         except comtypes.COMError as ce:
             self.duplicator.ReleaseFrame()
         try:
-            new_PointerInfo, new_PointerShape = self.get_frame_pointer_shape(info)
-            if new_PointerShape != False:
-                self.cursor.Shape = new_PointerShape
-                self.cursor.PointerShapeInfo = new_PointerInfo
+            if info.LastMouseUpdateTime > 0:
+                new_PointerInfo, new_PointerShape = self.get_frame_pointer_shape(info)
+                if new_PointerShape != False:
+                    self.cursor.Shape = new_PointerShape
+                    self.cursor.PointerShapeInfo = new_PointerInfo
                 self.cursor.PointerPositionInfo = info.PointerPosition
         except Exception as e: 
             print(e)
@@ -72,7 +71,6 @@ class Duplicator:
         hr = self.duplicator.GetFramePointerShape(FrameInfo.PointerShapeBufferSize, ctypes.byref(pPointerShapeBuffer), ctypes.byref(buffer_size_required), ctypes.byref(PointerShapeInfo)) 
         if FrameInfo.PointerShapeBufferSize > 0:
             #print("T",PointerShapeInfo.Type,PointerShapeInfo.Width,"x",PointerShapeInfo.Height,"Pitch:",PointerShapeInfo.Pitch,"HS:",PointerShapeInfo.HotSpot.x,PointerShapeInfo.HotSpot.y)
-            if PointerShapeInfo.Type != 2: return False, False # cant handle others rn
             return PointerShapeInfo, pPointerShapeBuffer
         return False, False
 

--- a/dxcam/core/duplicator.py
+++ b/dxcam/core/duplicator.py
@@ -78,12 +78,12 @@ class Duplicator:
         hr = self.duplicator.GetFramePointerShape(FrameInfo.PointerShapeBufferSize, ctypes.byref(pPointerShapeBuffer), ctypes.byref(buffer_size_required), ctypes.byref(PointerShapeInfo)) 
         if FrameInfo.PointerShapeBufferSize > 0:
             print("T",PointerShapeInfo.Type,PointerShapeInfo.Width,"x",PointerShapeInfo.Height,"Pitch:",PointerShapeInfo.Pitch,"HS:",PointerShapeInfo.HotSpot.x,PointerShapeInfo.HotSpot.y)
-            if PointerShapeInfo.Type != 2: return False # cant handle others rn
+            if PointerShapeInfo.Type != 2: return False, False # cant handle others rn
             return PointerShapeInfo, pPointerShapeBuffer
         #except:
         #    return False
         #return False
-        return False
+        return False, False
 
     def __repr__(self) -> str:
         return "<{} Initalized:{}>".format(

--- a/dxcam/core/duplicator.py
+++ b/dxcam/core/duplicator.py
@@ -6,6 +6,9 @@ from dxcam._libs.dxgi import *
 from dxcam.core.device import Device
 from dxcam.core.output import Output
 
+#class ac_Cursor:
+#    _fields_ = [("PointerPositionInfo",DXGI_OUTDUPL_POINTER_POSITION), ("PointerShapeInfo", DXGI_OUTDUPL_POINTER_SHAPE_INFO), ("Shape", bytes)]
+
 
 @dataclass
 class Duplicator:
@@ -14,6 +17,10 @@ class Duplicator:
     updated: bool = False
     output: InitVar[Output] = None
     device: InitVar[Device] = None
+    #cursor: ctypes.POINTER(ID3D11Texture2D) = ctypes.POINTER(ID3D11Texture2D)() #use proper type
+    cursor = ac_Cursor()
+    cursor.shape: bytes = None
+    cursor.PointerShapeInfo: DXGI_OUTDUPL_POINTER_SHAPE_INFO = DXGI_OUTDUPL_POINTER_SHAPE_INFO()  
 
     def __post_init__(self, output: Output, device: Device) -> None:
         self.duplicator = ctypes.POINTER(IDXGIOutputDuplication)()
@@ -24,7 +31,7 @@ class Duplicator:
         res = ctypes.POINTER(IDXGIResource)()
         try:
             self.duplicator.AcquireNextFrame(
-                10,
+                1000,
                 ctypes.byref(info),
                 ctypes.byref(res),
             )
@@ -43,6 +50,14 @@ class Duplicator:
             self.texture = res.QueryInterface(ID3D11Texture2D)
         except comtypes.COMError as ce:
             self.duplicator.ReleaseFrame()
+        try:
+            new_PointerInfo, new_PointerShape = self.get_frame_pointer_shape(info)
+            if new_PointerShape != False:
+                self.cursor.Shape = new_PointerShape
+                self.cursor.PointerShapeInfo = new_PointerInfo
+                self.cursor.PointerPositionInfo = info.PointerPosition
+        except Exception as e: 
+            print(e)
         self.updated = True
         return True
 
@@ -53,6 +68,22 @@ class Duplicator:
         if self.duplicator is not None:
             self.duplicator.Release()
             self.duplicator = None
+
+    def get_frame_pointer_shape(self, FrameInfo):
+        PointerShapeInfo = DXGI_OUTDUPL_POINTER_SHAPE_INFO()  
+        buffer_size_required = ctypes.c_uint()
+        pPointerShapeBuffer  = (ctypes.c_byte*FrameInfo.PointerShapeBufferSize)()
+        #try:
+            # Get shape
+        hr = self.duplicator.GetFramePointerShape(FrameInfo.PointerShapeBufferSize, ctypes.byref(pPointerShapeBuffer), ctypes.byref(buffer_size_required), ctypes.byref(PointerShapeInfo)) 
+        if FrameInfo.PointerShapeBufferSize > 0:
+            print("T",PointerShapeInfo.Type,PointerShapeInfo.Width,"x",PointerShapeInfo.Height,"Pitch:",PointerShapeInfo.Pitch,"HS:",PointerShapeInfo.HotSpot.x,PointerShapeInfo.HotSpot.y)
+            if PointerShapeInfo.Type != 2: return False # cant handle others rn
+            return PointerShapeInfo, pPointerShapeBuffer
+        #except:
+        #    return False
+        #return False
+        return False
 
     def __repr__(self) -> str:
         return "<{} Initalized:{}>".format(

--- a/dxcam/core/duplicator.py
+++ b/dxcam/core/duplicator.py
@@ -6,9 +6,6 @@ from dxcam._libs.dxgi import *
 from dxcam.core.device import Device
 from dxcam.core.output import Output
 
-#class ac_Cursor:
-#    _fields_ = [("PointerPositionInfo",DXGI_OUTDUPL_POINTER_POSITION), ("PointerShapeInfo", DXGI_OUTDUPL_POINTER_SHAPE_INFO), ("Shape", bytes)]
-
 
 @dataclass
 class Duplicator:
@@ -17,7 +14,6 @@ class Duplicator:
     updated: bool = False
     output: InitVar[Output] = None
     device: InitVar[Device] = None
-    #cursor: ctypes.POINTER(ID3D11Texture2D) = ctypes.POINTER(ID3D11Texture2D)() #use proper type
     cursor = ac_Cursor()
     cursor.shape: bytes = None
     cursor.PointerShapeInfo: DXGI_OUTDUPL_POINTER_SHAPE_INFO = DXGI_OUTDUPL_POINTER_SHAPE_INFO()  
@@ -31,7 +27,7 @@ class Duplicator:
         res = ctypes.POINTER(IDXGIResource)()
         try:
             self.duplicator.AcquireNextFrame(
-                1000,
+                10,
                 ctypes.byref(info),
                 ctypes.byref(res),
             )
@@ -73,16 +69,11 @@ class Duplicator:
         PointerShapeInfo = DXGI_OUTDUPL_POINTER_SHAPE_INFO()  
         buffer_size_required = ctypes.c_uint()
         pPointerShapeBuffer  = (ctypes.c_byte*FrameInfo.PointerShapeBufferSize)()
-        #try:
-            # Get shape
         hr = self.duplicator.GetFramePointerShape(FrameInfo.PointerShapeBufferSize, ctypes.byref(pPointerShapeBuffer), ctypes.byref(buffer_size_required), ctypes.byref(PointerShapeInfo)) 
         if FrameInfo.PointerShapeBufferSize > 0:
-            print("T",PointerShapeInfo.Type,PointerShapeInfo.Width,"x",PointerShapeInfo.Height,"Pitch:",PointerShapeInfo.Pitch,"HS:",PointerShapeInfo.HotSpot.x,PointerShapeInfo.HotSpot.y)
+            #print("T",PointerShapeInfo.Type,PointerShapeInfo.Width,"x",PointerShapeInfo.Height,"Pitch:",PointerShapeInfo.Pitch,"HS:",PointerShapeInfo.HotSpot.x,PointerShapeInfo.HotSpot.y)
             if PointerShapeInfo.Type != 2: return False, False # cant handle others rn
             return PointerShapeInfo, pPointerShapeBuffer
-        #except:
-        #    return False
-        #return False
         return False, False
 
     def __repr__(self) -> str:

--- a/dxcam/core/duplicator.py
+++ b/dxcam/core/duplicator.py
@@ -29,6 +29,12 @@ class Duplicator:
                 ctypes.byref(info),
                 ctypes.byref(res),
             )
+            if info.LastMouseUpdateTime > 0:
+                new_PointerInfo, new_PointerShape = self.get_frame_pointer_shape(info)
+                if new_PointerShape != False:
+                    self.cursor.Shape = new_PointerShape
+                    self.cursor.PointerShapeInfo = new_PointerInfo
+                self.cursor.PointerPositionInfo = info.PointerPosition
         except comtypes.COMError as ce:
             if ctypes.c_int32(DXGI_ERROR_ACCESS_LOST).value == ce.args[0] or ctypes.c_int32(ABANDONED_MUTEX_EXCEPTION).value == ce.args[0]:
                 self.release()  # Release resources before reinitializing
@@ -44,15 +50,7 @@ class Duplicator:
             self.texture = res.QueryInterface(ID3D11Texture2D)
         except comtypes.COMError as ce:
             self.duplicator.ReleaseFrame()
-        try:
-            if info.LastMouseUpdateTime > 0:
-                new_PointerInfo, new_PointerShape = self.get_frame_pointer_shape(info)
-                if new_PointerShape != False:
-                    self.cursor.Shape = new_PointerShape
-                    self.cursor.PointerShapeInfo = new_PointerInfo
-                self.cursor.PointerPositionInfo = info.PointerPosition
-        except Exception as e: 
-            print(e)
+
         self.updated = True
         return True
 

--- a/dxcam/dxcam.py
+++ b/dxcam/dxcam.py
@@ -89,7 +89,6 @@ class DXCamera:
         return self._grab(region)
     
     def grab_cursor(self):
-        #convert texture(bytearray) to surface
         return self._duplicator.cursor
 
 

--- a/dxcam/dxcam.py
+++ b/dxcam/dxcam.py
@@ -87,6 +87,11 @@ class DXCamera:
             self._validate_region(region)
 
         return self._grab(region)
+    
+    def grab_cursor(self):
+        #convert texture(bytearray) to surface
+        return self._duplicator.cursor
+
 
     def shot(self, image_ptr, region: Tuple[int, int, int, int] = None):
         if region is None:

--- a/dxcam/processor/numpy_processor.py
+++ b/dxcam/processor/numpy_processor.py
@@ -48,8 +48,8 @@ class NumpyProcessor(Processor):
         image = as_array(buffer, (height, width, 4))
 
         # Another approach from https://github.com/Agade09/DXcam
-        #buffer = (ctypes.c_char*height*width*4).from_address(ctypes.addressof(rect.pBits.contents))
-        #image = ndarray((height, width, 4), dtype=uint8, buffer=buffer)
+        # buffer = (ctypes.c_char*height*width*4).from_address(ctypes.addressof(rect.pBits.contents))
+        # image = ndarray((height, width, 4), dtype=uint8, buffer=buffer)
 
         if rotation_angle != 0:
             image = rot90(image, k=rotation_angle//90, axes=(1, 0))

--- a/dxcam/processor/numpy_processor.py
+++ b/dxcam/processor/numpy_processor.py
@@ -39,18 +39,17 @@ class NumpyProcessor(Processor):
         ctypes.memmove(image_ptr, rect.pBits, height*width*4)
 
     def process(self, rect, width, height, region, rotation_angle):
-        #print(self, rect, width, height, region, rotation_angle)
         width = region[2] - region[0]
         height = region[3] - region[1]
         if rotation_angle in (90, 270):
             width, height = height, width
 
-        #buffer = ctypes.cast(rect.pBits, self.PBYTE)
-        #image = as_array(buffer, (height, width, 4))
+        buffer = ctypes.cast(rect.pBits, self.PBYTE)
+        image = as_array(buffer, (height, width, 4))
 
         # Another approach from https://github.com/Agade09/DXcam
-        buffer = (ctypes.c_char*height*width*4).from_address(ctypes.addressof(rect.pBits.contents))
-        image = ndarray((height, width, 4), dtype=uint8, buffer=buffer)
+        #buffer = (ctypes.c_char*height*width*4).from_address(ctypes.addressof(rect.pBits.contents))
+        #image = ndarray((height, width, 4), dtype=uint8, buffer=buffer)
 
         if rotation_angle != 0:
             image = rot90(image, k=rotation_angle//90, axes=(1, 0))
@@ -59,49 +58,3 @@ class NumpyProcessor(Processor):
             return self.process_cvtcolor(image)
 
         return image
-    # def process(self, rect, width, height, region, rotation_angle):
-        # pitch = int(rect.Pitch)
-        # ptr = rect.pBits
-
-        # if region[3] - region[1] != height:
-            # if rotation_angle in (0, 180):
-                # offset = (region[1] if rotation_angle==0 else height-region[3])*pitch
-                # height = region[3] - region[1]
-            # else:
-                # offset = (region[0] if rotation_angle==270 else width-region[2])*pitch
-                # width = region[2] - region[0]
-            # ptr = ctypes.c_void_p(ctypes.addressof(ptr.contents)+offset)#Pointer arithmetic
-
-        # if rotation_angle in (0, 180):
-            # size = pitch * height
-        # else:
-            # size = pitch * width
-
-        # buffer = ctypes.string_at(ptr, size)
-        # pitch = pitch // 4
-        # if rotation_angle in (0, 180):
-            # image = np.ndarray((height, pitch, 4), dtype=np.uint8, buffer=buffer)
-        # elif rotation_angle in (90, 270):
-            # image = np.ndarray((width, pitch, 4), dtype=np.uint8, buffer=buffer)
-
-        # if not self.color_mode is None:
-            # image = self.process_cvtcolor(image)
-
-        # if rotation_angle == 90:
-            # image = np.rot90(image, axes=(1, 0))
-        # elif rotation_angle == 180:
-            # image = np.rot90(image, k=2, axes=(0, 1))
-        # elif rotation_angle == 270:
-            # image = np.rot90(image, axes=(0, 1))
-
-        # if rotation_angle in (0, 180) and pitch != width:
-            # image = image[:, :width, :]
-        # elif rotation_angle in (90, 270) and pitch != height:
-            # image = image[:height, :, :]
-
-        # if region[3] - region[1] != image.shape[0]:
-            # image = image[region[1] : region[3], :, :]
-        # if region[2] - region[0] != image.shape[1]:
-            # image = image[:, region[0] : region[2], :]
-
-        # return image

--- a/dxcam/processor/numpy_processor.py
+++ b/dxcam/processor/numpy_processor.py
@@ -39,17 +39,18 @@ class NumpyProcessor(Processor):
         ctypes.memmove(image_ptr, rect.pBits, height*width*4)
 
     def process(self, rect, width, height, region, rotation_angle):
+        #print(self, rect, width, height, region, rotation_angle)
         width = region[2] - region[0]
         height = region[3] - region[1]
         if rotation_angle in (90, 270):
             width, height = height, width
 
-        buffer = ctypes.cast(rect.pBits, self.PBYTE)
-        image = as_array(buffer, (height, width, 4))
+        #buffer = ctypes.cast(rect.pBits, self.PBYTE)
+        #image = as_array(buffer, (height, width, 4))
 
         # Another approach from https://github.com/Agade09/DXcam
-        # buffer = (ctypes.c_char*height*width*4).from_address(ctypes.addressof(rect.pBits.contents))
-        # image = ndarray((height, width, 4), dtype=uint8, buffer=buffer)
+        buffer = (ctypes.c_char*height*width*4).from_address(ctypes.addressof(rect.pBits.contents))
+        image = ndarray((height, width, 4), dtype=uint8, buffer=buffer)
 
         if rotation_angle != 0:
             image = rot90(image, k=rotation_angle//90, axes=(1, 0))
@@ -58,3 +59,49 @@ class NumpyProcessor(Processor):
             return self.process_cvtcolor(image)
 
         return image
+    # def process(self, rect, width, height, region, rotation_angle):
+        # pitch = int(rect.Pitch)
+        # ptr = rect.pBits
+
+        # if region[3] - region[1] != height:
+            # if rotation_angle in (0, 180):
+                # offset = (region[1] if rotation_angle==0 else height-region[3])*pitch
+                # height = region[3] - region[1]
+            # else:
+                # offset = (region[0] if rotation_angle==270 else width-region[2])*pitch
+                # width = region[2] - region[0]
+            # ptr = ctypes.c_void_p(ctypes.addressof(ptr.contents)+offset)#Pointer arithmetic
+
+        # if rotation_angle in (0, 180):
+            # size = pitch * height
+        # else:
+            # size = pitch * width
+
+        # buffer = ctypes.string_at(ptr, size)
+        # pitch = pitch // 4
+        # if rotation_angle in (0, 180):
+            # image = np.ndarray((height, pitch, 4), dtype=np.uint8, buffer=buffer)
+        # elif rotation_angle in (90, 270):
+            # image = np.ndarray((width, pitch, 4), dtype=np.uint8, buffer=buffer)
+
+        # if not self.color_mode is None:
+            # image = self.process_cvtcolor(image)
+
+        # if rotation_angle == 90:
+            # image = np.rot90(image, axes=(1, 0))
+        # elif rotation_angle == 180:
+            # image = np.rot90(image, k=2, axes=(0, 1))
+        # elif rotation_angle == 270:
+            # image = np.rot90(image, axes=(0, 1))
+
+        # if rotation_angle in (0, 180) and pitch != width:
+            # image = image[:, :width, :]
+        # elif rotation_angle in (90, 270) and pitch != height:
+            # image = image[:height, :, :]
+
+        # if region[3] - region[1] != image.shape[0]:
+            # image = image[region[1] : region[3], :, :]
+        # if region[2] - region[0] != image.shape[1]:
+            # image = image[:, region[0] : region[2], :]
+
+        # return image


### PR DESCRIPTION
Added dxcam.grab_cursor to retrieve PointerShape/PointerShapeInfo/PointerPositionInfo 
This allows access to cursor-related information for drawing purposes.

Added szDevice to dxcam.output_info to allow mapping to MONITORINFOEX 

These changes are used in https://github.com/scamiv/ActiveClone